### PR TITLE
Fix memoize function

### DIFF
--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -7,23 +7,24 @@
 export function memoize(fn, slot = null) {
     if (slot != null) {
         return function (obj, ...arg) {
-            if (obj.hasOwnProperty(slot)) {
-                return obj[slot];
+            if (!obj.hasOwnProperty(slot)) {
+                var new_val = fn(obj, ...arg);
+                obj[slot] = new_val;
+                return new_val;
+                
             }
-            else {
-                var val = fn(obj, ...arg);
-                obj[slot] = val;
-                return val;
-            }
+            return obj[slot];
         }
     }
     else {
         var cache = {};
         return function (...arg) {
             if (!cache.hasOwnProperty(arg)) {
-                cache[arg] = fn(...arg);
-                return cache[arg];
+                var new_val = fn(...arg)
+                cache[arg] = new_val;
+                return new_val;
             }
+            return cache[arg];
         }
     }
 }


### PR DESCRIPTION
In the branch with no slot the function didn’t return anything if the
arg was found in cache.