### PR TITLE
Fix disappearing walls when 'Start BFS' is clicked

### DIFF
--- a/3-Solving-Problems-By-Searching/index.html
+++ b/3-Solving-Problems-By-Searching/index.html
@@ -36,7 +36,7 @@
 
       <h2>Breadth First Search</h2>
       <p>Click on the canvas to restart the simulation</p>
-      <button type="button" onclick='init();breadthFirstSearch();'>Start BFS</button>
+      <button type="button" onclick='breadthFirstSearch();'>Start BFS</button>
       <button type="button" onclick='init()'>Reset</button>
       <div class = "canvas" id="breadthFirstSearchCanvas" height="300px" style="background: rgb(154, 255, 255);">
       </div>


### PR DESCRIPTION
When the simulation is started, all walls/barriers are cleared because `init()` was called again and again, when it should only be called to reset the grid.