### PR TITLE
Second visualization added for node expansion

### DIFF
--- a/3-Solving-Problems-By-Searching/c_nodeExpansion.js
+++ b/3-Solving-Problems-By-Searching/c_nodeExpansion.js
@@ -37,81 +37,6 @@ $(document).ready(function(){
     [0,0,0,0,0,0,0,0,0,1,1,0,0,0,1],
     [0,0,0,0,0,0,0,0,0,0,0,0,0,1,0]
   ];
-  function iterateGraph(){
-    for(var i = 0; i < nodeGroups.length; i++){
-      f_node = nodeGroups[i];
-      node = nodes[i];
-      state = problem.getState(i);
-      f_node._collection[0].fill = getColor(state);
-      if(state == 1){
-        $(f_node._renderer.elem).css('cursor','pointer');
-        f_node._renderer.elem.onclick = function(){
-          index = $(this).attr('nodeIndex');
-          problem.expand(index);
-          iterateGraph();
-        }
-      }else{
-        f_node._renderer.elem.onclick = null;
-      }
-    }
-    frontierTwo.clear();
-    var frontierNodes = problem.getExpandables();
-    for(var i=0;i<frontierNodes.length;i++){
-      node = nodes[frontierNodes[i]];
-      var x = (i%4)*50+40;
-      var y = (Math.floor(i/4))*50 + 20;
-      var circle = frontierTwo.makeCircle(x,y,nodeRadius);
-      var text = frontierTwo.makeText(node.text,x,y);
-      circle.fill = frontierColor;
-    }
-    frontierTwo.update();
-    two.update();
-  }
-  function drawGraph(){
-    //Draw Edges
-    for(var i=0; i < adjMatrix.length; i++){
-      for(var j=0; j< adjMatrix[i].length; j++){
-        if(adjMatrix[i][j]){
-          var line = two.makeLine(nodes[i].x,nodes[i].y,nodes[j].x , nodes[j].y);
-          $(line._renderer.elem).attr('nodesIndices',i+"_"+j)
-          line.linewidth = 2;
-        }
-      }
-    }
-    //Draw Nodes
-    for(var i = 0; i < nodes.length; i++){
-      node = nodes[i];
-      var circle = two.makeCircle(node.x,node.y,nodeRadius);
-      circle.fill = getColor(problem.getState(i));
-      var text = two.makeText(node.text,node.x,node.y);
-      var group = two.makeGroup(circle,text);
-      nodeGroups.push(group);
-      two.update();
-      $(group._renderer.elem).attr('nodeIndex',i);
-      if(problem.getState(i) == 1){
-        $(group._renderer.elem).css('cursor','pointer');
-        group._renderer.elem.onclick = function(){
-          index = $(this).attr('nodeIndex');
-          problem.expand(index);
-          iterateGraph();
-        }
-      }
-    }
-    //Draw nodes in frontier block
-    frontierCanvas = document.getElementById('frontierCanvas');
-    frontierCanvas.innerHTML = '';
-    frontierTwo = new Two().appendTo(frontierCanvas);
-    var frontierNodes = problem.getExpandables();
-    for(var i=0;i<frontierNodes.length;i++){
-      node = nodes[frontierNodes[i]];
-      var x = (i%4)*50+40;
-      var y = (Math.floor(i/4))*50 + 20;
-      var circle = frontierTwo.makeCircle(x,y,nodeRadius);
-      var text = frontierTwo.makeText(node.text,x,y);
-      circle.fill = frontierColor;
-    }
-    frontierTwo.update();
-  }
 
   function init(){
     canvas = document.getElementById('nodeExpansionCanvas');
@@ -121,7 +46,7 @@ $(document).ready(function(){
       this.frontierCanvas = document.getElementById('frontierCanvas');
       this.frontierCanvas.innerHTML = '';
       this.frontierTwo = new Two().appendTo(frontierCanvas);
-      this.rontierNodes = this.agent.getExpandables();
+      this.frontierNodes = this.agent.getExpandables();
       for(var i=0;i<this.frontierNodes.length;i++){
         node = this.nodes[this.frontierNodes[i]];
         var x = (i%4)*50+40;
@@ -132,11 +57,166 @@ $(document).ready(function(){
       }
       this.frontierTwo.update();
     }
+
+    visGraph.extraIterate = function(){
+      this.frontierTwo.clear();
+      this.frontierNodes = this.agent.getExpandables();
+      for(var i=0;i<this.frontierNodes.length;i++){
+        node = this.nodes[this.frontierNodes[i]];
+        var x = (i%4)*50+40;
+        var y = (Math.floor(i/4))*50 + 20;
+        var circle = this.frontierTwo.makeCircle(x,y,this.nodeRadius);
+        var text = this.frontierTwo.makeText(node.text,x,y);
+        circle.fill = this.frontierColor;
+      }
+      this.frontierTwo.update();
+    }
+
+
     visGraph.init();
     $('#legendExpanded').css('background-color',visGraph.expandedColor);
     $('#legendFrontier').css('background-color',visGraph.frontierColor);
     $('#legendUnexplored').css('background-color',visGraph.unvisitedColor);
   };
   $('#nodeRestartButton').click(init);
+  init();
+});
+$(document).ready(function(){
+  var w = 600, h = 350;
+  var initial = 0;
+  var visGraph = null;
+  var nodes = [
+    {x:50,y:100,text:"A"},
+    {x:20,y:150,text:"B"},
+    {x:75,y:180,text:"C"},
+    {x:100,y:100,text:"D"},
+    {x:230,y:100,text:"E"},
+    {x:180,y:160,text:"F"},
+    {x:70,y:300,text:"G"},
+    {x:120,y:240,text:"H"},
+    {x:300,y:150,text:"I"},
+    {x:280,y:250,text:"J"},
+    {x:400,y:220,text:"K"},
+    {x:200,y:280,text:"L"},
+    {x:380,y:100,text:"M"},
+    {x:350,y:300,text:"N"},
+    {x:450,y:320,text:"O"}
+  ];
+  var adjMatrix = [
+  // a,b,c,d,e,f,g,h,i,j,k,l,m,n,o
+    [0,1,0,1,0,0,0,0,0,0,0,0,0,0,0],
+    [1,0,1,0,0,0,0,0,0,0,0,0,0,0,0],
+    [0,1,0,1,0,0,1,1,0,0,0,0,0,0,0],
+    [1,0,1,0,1,1,0,0,0,0,0,0,0,0,0],
+    [0,0,0,1,0,0,0,0,1,0,0,0,0,0,0],
+    [0,0,0,1,0,0,0,0,0,1,0,0,0,0,0],
+    [0,0,1,0,0,0,0,0,0,0,0,0,0,0,0],
+    [0,0,1,0,0,0,0,0,0,0,0,1,0,0,0],
+    [0,0,0,0,1,0,0,0,0,1,1,0,1,0,0],
+    [0,0,0,0,0,1,0,0,1,0,0,1,0,1,0],
+    [0,0,0,0,0,0,0,0,1,0,0,0,0,1,0],
+    [0,0,0,0,0,0,0,1,0,1,0,0,0,0,0],
+    [0,0,0,0,0,0,0,0,1,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0,0,0,1,1,0,0,0,1],
+    [0,0,0,0,0,0,0,0,0,0,0,0,0,1,0]
+  ];
+
+  function init(){
+    canvas = document.getElementById('agentViewCanvas');
+    agent = new nodeExpansionAgent(adjMatrix,Math.floor(Math.random()*15));
+    visGraph = new visualGraph(canvas,h,w,agent,nodes,adjMatrix);
+    visGraph.init = function(){
+      var self = visGraph;
+      visGraph.canvas.innerHTML = '';
+      visGraph.two = new Two({height:h,width:w}).appendTo(canvas);
+      //Draw edges first so they appear behind nodes.
+      for(var i=0; i < visGraph.adjMatrix.length; i++){
+        for(var j=0; j< visGraph.adjMatrix[i].length; j++){
+          if(visGraph.adjMatrix[i][j]){
+            var line = visGraph.two.makeLine(visGraph.nodes[i].x,visGraph.nodes[i].y,visGraph.nodes[j].x , visGraph.nodes[j].y);
+            line.linewidth = 2;
+            this.edges.push(line);
+            visGraph.two.update();
+            $(line._renderer.elem).attr('nodesIndices',i+"_"+j);
+
+            if(visGraph.agent.getState(i) == 0 || visGraph.agent.getState(j) == 0){
+              line.visible = false;
+            }
+          }
+        }
+      }
+      //Draw Nodes
+
+      for(var i = 0; i < visGraph.nodes.length; i++){
+        node = visGraph.nodes[i];
+        var circle = visGraph.two.makeCircle(node.x,node.y,visGraph.nodeRadius);
+        circle.fill = visGraph.drawCode[visGraph.agent.getState(i)].color;
+        var text = visGraph.two.makeText(node.text,node.x,node.y);
+        var group = visGraph.two.makeGroup(circle,text);
+        visGraph.nodeGroups.push(group);
+        visGraph.two.update();
+        $(group._renderer.elem).attr('nodeIndex',i);
+        if(visGraph.agent.getState(i) == 0){
+          group.visible = false;
+        }
+        if(visGraph.agent.getState(i) == 1){
+          $(group._renderer.elem).css('cursor','pointer');
+          group._renderer.elem.onclick = function(){
+            index = $(this).attr('nodeIndex');
+            self.agent.expand(index);
+            self.iterate();
+          }
+        }
+      }
+      if(visGraph.extraDraw){
+        visGraph.extraDraw();
+      }
+      visGraph.two.update();
+    };
+
+    visGraph.iterate = function(callback){
+      var self = visGraph;
+
+      for(var i = 0; i < visGraph.nodeGroups.length; i++){
+        f_node = visGraph.nodeGroups[i];
+        node = visGraph.nodes[i];
+        state = visGraph.agent.getState(i);
+        f_node._collection[0].fill = visGraph.drawCode[state].color;
+        if(state > 0){
+          f_node.visible = true;
+        }
+        if(state == 1){
+          $(f_node._renderer.elem).css('cursor','pointer');
+          f_node._renderer.elem.onclick = function(){
+            index = $(this).attr('nodeIndex');
+            self.agent.expand(index);
+            self.iterate();
+          }
+        }else{
+          f_node._renderer.elem.onclick = null;
+        }
+      }
+
+      for(var i = 0;i < visGraph.edges.length;i++){
+        edge = visGraph.edges[i];
+        x = $(edge._renderer.elem).attr('nodesIndices');
+        ar = x.split('_');
+        a = ar[0];
+        b = ar[1];
+        if(visGraph.agent.getState(a) > 0 && visGraph.agent.getState(b) > 0){
+          edge.visible = true;
+        }else{
+          edge.visible = false;
+        }
+      }
+
+
+      visGraph.two.update();
+    };
+
+
+    visGraph.init();
+  };
+  $('#agentViewRestartButton').click(init);
   init();
 });

--- a/3-Solving-Problems-By-Searching/c_nodeExpansion.js
+++ b/3-Solving-Problems-By-Searching/c_nodeExpansion.js
@@ -37,13 +37,100 @@ $(document).ready(function(){
     [0,0,0,0,0,0,0,0,0,1,1,0,0,0,1],
     [0,0,0,0,0,0,0,0,0,0,0,0,0,1,0]
   ];
+  function iterateGraph(){
+    for(var i = 0; i < nodeGroups.length; i++){
+      f_node = nodeGroups[i];
+      node = nodes[i];
+      state = problem.getState(i);
+      f_node._collection[0].fill = getColor(state);
+      if(state == 1){
+        $(f_node._renderer.elem).css('cursor','pointer');
+        f_node._renderer.elem.onclick = function(){
+          index = $(this).attr('nodeIndex');
+          problem.expand(index);
+          iterateGraph();
+        }
+      }else{
+        f_node._renderer.elem.onclick = null;
+      }
+    }
+    frontierTwo.clear();
+    var frontierNodes = problem.getExpandables();
+    for(var i=0;i<frontierNodes.length;i++){
+      node = nodes[frontierNodes[i]];
+      var x = (i%4)*50+40;
+      var y = (Math.floor(i/4))*50 + 20;
+      var circle = frontierTwo.makeCircle(x,y,nodeRadius);
+      var text = frontierTwo.makeText(node.text,x,y);
+      circle.fill = frontierColor;
+    }
+    frontierTwo.update();
+    two.update();
+  }
+  function drawGraph(){
+    //Draw Edges
+    for(var i=0; i < adjMatrix.length; i++){
+      for(var j=0; j< adjMatrix[i].length; j++){
+        if(adjMatrix[i][j]){
+          var line = two.makeLine(nodes[i].x,nodes[i].y,nodes[j].x , nodes[j].y);
+          $(line._renderer.elem).attr('nodesIndices',i+"_"+j)
+          line.linewidth = 2;
+        }
+      }
+    }
+    //Draw Nodes
+    for(var i = 0; i < nodes.length; i++){
+      node = nodes[i];
+      var circle = two.makeCircle(node.x,node.y,nodeRadius);
+      circle.fill = getColor(problem.getState(i));
+      var text = two.makeText(node.text,node.x,node.y);
+      var group = two.makeGroup(circle,text);
+      nodeGroups.push(group);
+      two.update();
+      $(group._renderer.elem).attr('nodeIndex',i);
+      if(problem.getState(i) == 1){
+        $(group._renderer.elem).css('cursor','pointer');
+        group._renderer.elem.onclick = function(){
+          index = $(this).attr('nodeIndex');
+          problem.expand(index);
+          iterateGraph();
+        }
+      }
+    }
+    //Draw nodes in frontier block
+    frontierCanvas = document.getElementById('frontierCanvas');
+    frontierCanvas.innerHTML = '';
+    frontierTwo = new Two().appendTo(frontierCanvas);
+    var frontierNodes = problem.getExpandables();
+    for(var i=0;i<frontierNodes.length;i++){
+      node = nodes[frontierNodes[i]];
+      var x = (i%4)*50+40;
+      var y = (Math.floor(i/4))*50 + 20;
+      var circle = frontierTwo.makeCircle(x,y,nodeRadius);
+      var text = frontierTwo.makeText(node.text,x,y);
+      circle.fill = frontierColor;
+    }
+    frontierTwo.update();
+  }
 
   function init(){
     canvas = document.getElementById('nodeExpansionCanvas');
     agent = new nodeExpansionAgent(adjMatrix,0);
     visGraph = new visualGraph(canvas,h,w,agent,nodes,adjMatrix);
     visGraph.extraDraw = function(){
-      
+      this.frontierCanvas = document.getElementById('frontierCanvas');
+      this.frontierCanvas.innerHTML = '';
+      this.frontierTwo = new Two().appendTo(frontierCanvas);
+      this.rontierNodes = this.agent.getExpandables();
+      for(var i=0;i<this.frontierNodes.length;i++){
+        node = this.nodes[this.frontierNodes[i]];
+        var x = (i%4)*50+40;
+        var y = (Math.floor(i/4))*50 + 20;
+        var circle = this.frontierTwo.makeCircle(x,y,this.nodeRadius);
+        var text = this.frontierTwo.makeText(node.text,x,y);
+        circle.fill = this.drawCode[1].color;
+      }
+      this.frontierTwo.update();
     }
     visGraph.init();
     $('#legendExpanded').css('background-color',visGraph.expandedColor);

--- a/3-Solving-Problems-By-Searching/c_nodeExpansion.js
+++ b/3-Solving-Problems-By-Searching/c_nodeExpansion.js
@@ -43,7 +43,7 @@ $(document).ready(function(){
     [0,0,0,0,0,0,0,0,0,0,0,0,0,1,0]
   ];
 
-  var f_nodes = [];
+  var nodeGroups = [];
 
   function getColor(state){
     if(state == 0){
@@ -56,7 +56,34 @@ $(document).ready(function(){
   }
 
   function iterateGraph(){
-
+    for(var i = 0; i < nodeGroups.length; i++){
+      f_node = nodeGroups[i];
+      node = nodes[i];
+      state = problem.getState(i);
+      f_node._collection[0].fill = getColor(state);
+      if(state == 1){
+        $(f_node._renderer.elem).css('cursor','pointer');
+        f_node._renderer.elem.onclick = function(){
+          index = $(this).attr('nodeIndex');
+          problem.expand(index);
+          iterateGraph();
+        }
+      }else{
+        f_node._renderer.elem.onclick = null;
+      }
+    }
+    frontierTwo.clear();
+    var frontierNodes = problem.getExpandables();
+    for(var i=0;i<frontierNodes.length;i++){
+      node = nodes[frontierNodes[i]];
+      var x = (i%4)*50+40;
+      var y = (Math.floor(i/4))*50 + 20;
+      var circle = frontierTwo.makeCircle(x,y,nodeRadius);
+      var text = frontierTwo.makeText(node.text,x,y);
+      circle.fill = frontierColor;
+    }
+    frontierTwo.update();
+    two.update();
   }
   function drawGraph(){
     //Draw Edges
@@ -76,7 +103,7 @@ $(document).ready(function(){
       circle.fill = getColor(problem.getState(i));
       var text = two.makeText(node.text,node.x,node.y);
       var group = two.makeGroup(circle,text);
-      f_nodes.push(group);
+      nodeGroups.push(group);
       two.update();
       $(group._renderer.elem).attr('nodeIndex',i);
       if(problem.getState(i) == 1){
@@ -100,13 +127,14 @@ $(document).ready(function(){
       var circle = frontierTwo.makeCircle(x,y,nodeRadius);
       var text = frontierTwo.makeText(node.text,x,y);
       circle.fill = frontierColor;
-      frontierTwo.update();
     }
+    frontierTwo.update();
   }
 
   function init(){
     canvas = document.getElementById('nodeExpansionCanvas');
     canvas.innerHTML = '';
+    nodeGroups = [];
     two = new Two({height:h,width:w}).appendTo(canvas);
     problem = new nodeExpansionProblem(adjMatrix,0);
     $('#legendExpanded').css('background-color',expandedColor);

--- a/3-Solving-Problems-By-Searching/c_nodeExpansion.js
+++ b/3-Solving-Problems-By-Searching/c_nodeExpansion.js
@@ -1,0 +1,116 @@
+$(document).ready(function(){
+  var two,frontierTwo,canvas,frontierCanvas;
+  var w = 600, h = 350;
+  var initial = 0;
+
+  var unvisitedColor = '#c4c2c2';
+  var frontierColor = '#59acff';
+  var expandedColor = '#c64f4f';
+  var nodeRadius = 15;
+  var nodes = [
+    {x:50,y:100,text:"A"},
+    {x:20,y:150,text:"B"},
+    {x:75,y:180,text:"C"},
+    {x:100,y:100,text:"D"},
+    {x:230,y:100,text:"E"},
+    {x:180,y:160,text:"F"},
+    {x:70,y:300,text:"G"},
+    {x:120,y:240,text:"H"},
+    {x:300,y:150,text:"I"},
+    {x:280,y:250,text:"J"},
+    {x:400,y:220,text:"K"},
+    {x:200,y:280,text:"L"},
+    {x:380,y:100,text:"M"},
+    {x:350,y:300,text:"N"},
+    {x:450,y:320,text:"O"}
+  ];
+  var adjMatrix = [
+  // a,b,c,d,e,f,g,h,i,j,k,l,m,n,o
+    [0,1,0,1,0,0,0,0,0,0,0,0,0,0,0],
+    [1,0,1,0,0,0,0,0,0,0,0,0,0,0,0],
+    [0,1,0,1,0,0,1,1,0,0,0,0,0,0,0],
+    [1,0,1,0,1,1,0,0,0,0,0,0,0,0,0],
+    [0,0,0,1,0,0,0,0,1,0,0,0,0,0,0],
+    [0,0,0,1,0,0,0,0,0,1,0,0,0,0,0],
+    [0,0,1,0,0,0,0,0,0,0,0,0,0,0,0],
+    [0,0,1,0,0,0,0,0,0,0,0,1,0,0,0],
+    [0,0,0,0,1,0,0,0,0,1,1,0,1,0,0],
+    [0,0,0,0,0,1,0,0,1,0,0,1,0,1,0],
+    [0,0,0,0,0,0,0,0,1,0,0,0,0,1,0],
+    [0,0,0,0,0,0,0,1,0,1,0,0,0,0,0],
+    [0,0,0,0,0,0,0,0,1,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0,0,0,1,1,0,0,0,1],
+    [0,0,0,0,0,0,0,0,0,0,0,0,0,1,0]
+  ];
+
+  var f_nodes = [];
+
+  function getColor(state){
+    if(state == 0){
+      return unvisitedColor;
+    }
+    if(state == 1){
+      return frontierColor;
+    }
+    return expandedColor;
+  }
+
+  function drawGraph(){
+    //Draw Edges
+    for(var i=0; i < adjMatrix.length; i++){
+      for(var j=0; j< adjMatrix[i].length; j++){
+        if(adjMatrix[i][j]){
+          var line = two.makeLine(nodes[i].x,nodes[i].y,nodes[j].x , nodes[j].y);
+          $(line._renderer.elem).attr('nodesIndices',i+"_"+j)
+          line.linewidth = 2;
+        }
+      }
+    }
+    //Draw Nodes
+    for(var i = 0; i < nodes.length; i++){
+      node = nodes[i];
+      var circle = two.makeCircle(node.x,node.y,nodeRadius);
+      circle.fill = getColor(problem.getState(i));
+      var text = two.makeText(node.text,node.x,node.y);
+      var group = two.makeGroup(circle,text);
+      f_nodes.push(group);
+      two.update();
+      $(group._renderer.elem).attr('nodeIndex',i);
+      if(problem.getState(i) == 1){
+        $(group._renderer.elem).css('cursor','pointer');
+        group._renderer.elem.onclick = function(){
+          index = $(this).attr('nodeIndex');
+          problem.expand(index);
+          drawGraph();
+        }
+      }
+    }
+    //Draw nodes in frontier block
+    frontierCanvas = document.getElementById('frontierCanvas');
+    frontierCanvas.innerHTML = '';
+    frontierTwo = new Two().appendTo(frontierCanvas);
+    var frontierNodes = problem.getExpandables();
+    for(var i=0;i<frontierNodes.length;i++){
+      node = nodes[frontierNodes[i]];
+      var x = (i%4)*50+40;
+      var y = (Math.floor(i/4))*50 + 20;
+      var circle = frontierTwo.makeCircle(x,y,nodeRadius);
+      var text = frontierTwo.makeText(node.text,x,y);
+      circle.fill = frontierColor;
+      frontierTwo.update();
+    }
+  }
+
+  function init(){
+    canvas = document.getElementById('nodeExpansionCanvas');
+    canvas.innerHTML = '';
+    two = new Two({height:h,width:w}).appendTo(canvas);
+    problem = new nodeExpansionProblem(adjMatrix,0);
+    $('#legendExpanded').css('background-color',expandedColor);
+    $('#legendFrontier').css('background-color',frontierColor);
+    $('#legendUnexplored').css('background-color',unvisitedColor);
+    drawGraph();
+  };
+  $('#nodeRestartButton').click(init);
+  init();
+});

--- a/3-Solving-Problems-By-Searching/c_nodeExpansion.js
+++ b/3-Solving-Problems-By-Searching/c_nodeExpansion.js
@@ -1,12 +1,7 @@
 $(document).ready(function(){
-  var two,frontierTwo,canvas,frontierCanvas;
   var w = 600, h = 350;
   var initial = 0;
-
-  var unvisitedColor = 'hsl(0, 2%, 76%)';
-  var frontierColor = 'hsl(200,50%,70%)';
-  var expandedColor = 'hsl(0,50%,75%)';
-  var nodeRadius = 15;
+  var visGraph = null;
   var nodes = [
     {x:50,y:100,text:"A"},
     {x:20,y:150,text:"B"},
@@ -43,104 +38,17 @@ $(document).ready(function(){
     [0,0,0,0,0,0,0,0,0,0,0,0,0,1,0]
   ];
 
-  var nodeGroups = [];
-
-  function getColor(state){
-    if(state == 0){
-      return unvisitedColor;
-    }
-    if(state == 1){
-      return frontierColor;
-    }
-    return expandedColor;
-  }
-
-  function iterateGraph(){
-    for(var i = 0; i < nodeGroups.length; i++){
-      f_node = nodeGroups[i];
-      node = nodes[i];
-      state = problem.getState(i);
-      f_node._collection[0].fill = getColor(state);
-      if(state == 1){
-        $(f_node._renderer.elem).css('cursor','pointer');
-        f_node._renderer.elem.onclick = function(){
-          index = $(this).attr('nodeIndex');
-          problem.expand(index);
-          iterateGraph();
-        }
-      }else{
-        f_node._renderer.elem.onclick = null;
-      }
-    }
-    frontierTwo.clear();
-    var frontierNodes = problem.getExpandables();
-    for(var i=0;i<frontierNodes.length;i++){
-      node = nodes[frontierNodes[i]];
-      var x = (i%4)*50+40;
-      var y = (Math.floor(i/4))*50 + 20;
-      var circle = frontierTwo.makeCircle(x,y,nodeRadius);
-      var text = frontierTwo.makeText(node.text,x,y);
-      circle.fill = frontierColor;
-    }
-    frontierTwo.update();
-    two.update();
-  }
-  function drawGraph(){
-    //Draw Edges
-    for(var i=0; i < adjMatrix.length; i++){
-      for(var j=0; j< adjMatrix[i].length; j++){
-        if(adjMatrix[i][j]){
-          var line = two.makeLine(nodes[i].x,nodes[i].y,nodes[j].x , nodes[j].y);
-          $(line._renderer.elem).attr('nodesIndices',i+"_"+j)
-          line.linewidth = 2;
-        }
-      }
-    }
-    //Draw Nodes
-    for(var i = 0; i < nodes.length; i++){
-      node = nodes[i];
-      var circle = two.makeCircle(node.x,node.y,nodeRadius);
-      circle.fill = getColor(problem.getState(i));
-      var text = two.makeText(node.text,node.x,node.y);
-      var group = two.makeGroup(circle,text);
-      nodeGroups.push(group);
-      two.update();
-      $(group._renderer.elem).attr('nodeIndex',i);
-      if(problem.getState(i) == 1){
-        $(group._renderer.elem).css('cursor','pointer');
-        group._renderer.elem.onclick = function(){
-          index = $(this).attr('nodeIndex');
-          problem.expand(index);
-          iterateGraph();
-        }
-      }
-    }
-    //Draw nodes in frontier block
-    frontierCanvas = document.getElementById('frontierCanvas');
-    frontierCanvas.innerHTML = '';
-    frontierTwo = new Two().appendTo(frontierCanvas);
-    var frontierNodes = problem.getExpandables();
-    for(var i=0;i<frontierNodes.length;i++){
-      node = nodes[frontierNodes[i]];
-      var x = (i%4)*50+40;
-      var y = (Math.floor(i/4))*50 + 20;
-      var circle = frontierTwo.makeCircle(x,y,nodeRadius);
-      var text = frontierTwo.makeText(node.text,x,y);
-      circle.fill = frontierColor;
-    }
-    frontierTwo.update();
-  }
-
   function init(){
     canvas = document.getElementById('nodeExpansionCanvas');
-    canvas.innerHTML = '';
-    nodeGroups = [];
-    two = new Two({height:h,width:w}).appendTo(canvas);
-    problem = new nodeExpansionProblem(adjMatrix,0);
-    $('#legendExpanded').css('background-color',expandedColor);
-    $('#legendFrontier').css('background-color',frontierColor);
-    $('#legendUnexplored').css('background-color',unvisitedColor);
-    drawGraph();
+    agent = new nodeExpansionAgent(adjMatrix,0);
+    visGraph = new visualGraph(canvas,h,w,agent,nodes,adjMatrix);
+    visGraph.extraDraw = function(){
+      
+    }
+    visGraph.init();
+    $('#legendExpanded').css('background-color',visGraph.expandedColor);
+    $('#legendFrontier').css('background-color',visGraph.frontierColor);
+    $('#legendUnexplored').css('background-color',visGraph.unvisitedColor);
   };
   $('#nodeRestartButton').click(init);
   init();

--- a/3-Solving-Problems-By-Searching/c_nodeExpansion.js
+++ b/3-Solving-Problems-By-Searching/c_nodeExpansion.js
@@ -3,9 +3,9 @@ $(document).ready(function(){
   var w = 600, h = 350;
   var initial = 0;
 
-  var unvisitedColor = '#c4c2c2';
-  var frontierColor = '#59acff';
-  var expandedColor = '#c64f4f';
+  var unvisitedColor = 'hsl(0, 2%, 76%)';
+  var frontierColor = 'hsl(200,50%,70%)';
+  var expandedColor = 'hsl(0,50%,75%)';
   var nodeRadius = 15;
   var nodes = [
     {x:50,y:100,text:"A"},
@@ -55,6 +55,9 @@ $(document).ready(function(){
     return expandedColor;
   }
 
+  function iterateGraph(){
+
+  }
   function drawGraph(){
     //Draw Edges
     for(var i=0; i < adjMatrix.length; i++){
@@ -81,7 +84,7 @@ $(document).ready(function(){
         group._renderer.elem.onclick = function(){
           index = $(this).attr('nodeIndex');
           problem.expand(index);
-          drawGraph();
+          iterateGraph();
         }
       }
     }

--- a/3-Solving-Problems-By-Searching/helpers.js
+++ b/3-Solving-Problems-By-Searching/helpers.js
@@ -82,6 +82,7 @@ var visualGraph = function(canvas,h,w,agent,nodes,adjMatrix) {
   this.agent = agent;
   this.nodeRadius = 15;
   this.nodeGroups = [];
+  this.edges = [];
   this.nodes = nodes;
   this.adjMatrix = adjMatrix;
   this.unvisitedColor = 'hsl(0, 2%, 76%)';
@@ -92,16 +93,13 @@ var visualGraph = function(canvas,h,w,agent,nodes,adjMatrix) {
 
   this.drawCode = {
     0:{
-      color:this.unvisitedColor,
-      opacity:1
+      color:this.unvisitedColor
     },
     1:{
-      color:this.frontierColor,
-      opacity:1
+      color:this.frontierColor
     },
     2:{
-      color:this.expandedColor,
-      opacity:1
+      color:this.expandedColor
     }
   };
 
@@ -114,8 +112,10 @@ var visualGraph = function(canvas,h,w,agent,nodes,adjMatrix) {
       for(var j=0; j< this.adjMatrix[i].length; j++){
         if(this.adjMatrix[i][j]){
           var line = this.two.makeLine(this.nodes[i].x,this.nodes[i].y,this.nodes[j].x , this.nodes[j].y);
-          $(line._renderer.elem).attr('nodesIndices',i+"_"+j)
           line.linewidth = 2;
+          this.edges.push(line);
+          this.two.update();
+          $(line._renderer.elem).attr('nodesIndices',i+"_"+j)
         }
       }
     }
@@ -125,7 +125,6 @@ var visualGraph = function(canvas,h,w,agent,nodes,adjMatrix) {
       node = this.nodes[i];
       var circle = this.two.makeCircle(node.x,node.y,this.nodeRadius);
       circle.fill = this.drawCode[this.agent.getState(i)].color;
-      circle.opacity = this.drawCode[this.agent.getState(i)].opacity;
       var text = this.two.makeText(node.text,node.x,node.y);
       var group = this.two.makeGroup(circle,text);
       this.nodeGroups.push(group);
@@ -143,7 +142,7 @@ var visualGraph = function(canvas,h,w,agent,nodes,adjMatrix) {
     if(this.extraDraw){
       this.extraDraw();
     }
-    this.two.update():
+    this.two.update();
   };
 
   this.iterate = function(callback){
@@ -154,7 +153,6 @@ var visualGraph = function(canvas,h,w,agent,nodes,adjMatrix) {
       node = this.nodes[i];
       state = this.agent.getState(i);
       f_node._collection[0].fill = this.drawCode[state].color;
-      f_node._collection[0].opacity = this.drawCode[state].opacity;
       if(state == 1){
         $(f_node._renderer.elem).css('cursor','pointer');
         f_node._renderer.elem.onclick = function(){

--- a/3-Solving-Problems-By-Searching/helpers.js
+++ b/3-Solving-Problems-By-Searching/helpers.js
@@ -1,77 +1,5 @@
 
 
-// Returns a random graph. Might be useful for later visualizations.
-var randomGraphGenerator = function(size,h,w,nodeRadius){
-  function distance(node1,node2){
-    return Math.sqrt(Math.pow((node1.x - node2.x),2)+Math.pow((node1.y-node2.y),2));
-  }
-
-  function getDegree(){
-    let x = Math.random();
-    if(x < 0.05){
-      return 0;
-    }
-    if(x < 0.1){
-      return 1;
-    }
-    if(x < 0.75){
-      return 2;
-    }
-    return 3;
-  }
-  var gap = 40;
-  var nodes = [];
-  //Creating Random Nodes
-  for(var i=0;i<size;i++){
-    var node = {};
-    node.x = Math.floor(Math.random()*(w-nodeRadius))+nodeRadius;
-    node.y = Math.floor(Math.random()*(h-nodeRadius))+nodeRadius;
-    node.text = i;
-    node.degree = getDegree();
-    var acceptable = true;
-    for(var j=0;j<nodes.length;j++){
-      snode = nodes[j];
-      if(distance(snode,node) < (nodeRadius+gap)){
-        acceptable = false;
-        break;
-      }
-    }
-    if(acceptable){
-      nodes.push(node);
-    }else{
-      i--;
-    }
-  }
-  //Create empty adjacency Matrix
-  var adjMatrix = [];
-  for(var i=0;i<nodes.length;i++){
-    x = [];
-    for(var j=0;j<nodes.length;j++){
-      x.push(0);
-    }
-    adjMatrix.push(x);
-  }
-  //Fill adjacency matrix according to degree of the nodes
-  for(var i=0;i<nodes.length;i++){
-    var currNode = nodes[i];
-    var distances = [];
-    for(var j=0;j<nodes.length;j++){
-      if(i != j){
-        distances.push({index:j,distance:distance(currNode,nodes[j])});
-      }
-    }
-    distances = distances.sort(function(a,b){
-      return a.distance - b.distance;
-    });
-
-    for(var j=0; j<currNode.degree;j++){
-      adjMatrix[i][distances[j].index] = 1;
-      adjMatrix[distances[j].index][i] = 1;
-    }
-  }
-
-  return {nodes:nodes,matrix:adjMatrix};
-}
 
 // Class for drawing graphs on the page
 var visualGraph = function(canvas,h,w,agent,nodes,adjMatrix) {
@@ -145,7 +73,7 @@ var visualGraph = function(canvas,h,w,agent,nodes,adjMatrix) {
     this.two.update();
   };
 
-  this.iterate = function(callback){
+  this.iterate = function(){
     var self = this;
 
     for(var i = 0; i < this.nodeGroups.length; i++){

--- a/3-Solving-Problems-By-Searching/helpers.js
+++ b/3-Solving-Problems-By-Searching/helpers.js
@@ -1,0 +1,175 @@
+
+
+// Returns a random graph. Might be useful for later visualizations.
+var randomGraphGenerator = function(size,h,w,nodeRadius){
+  function distance(node1,node2){
+    return Math.sqrt(Math.pow((node1.x - node2.x),2)+Math.pow((node1.y-node2.y),2));
+  }
+
+  function getDegree(){
+    let x = Math.random();
+    if(x < 0.05){
+      return 0;
+    }
+    if(x < 0.1){
+      return 1;
+    }
+    if(x < 0.75){
+      return 2;
+    }
+    return 3;
+  }
+  var gap = 40;
+  var nodes = [];
+  //Creating Random Nodes
+  for(var i=0;i<size;i++){
+    var node = {};
+    node.x = Math.floor(Math.random()*(w-nodeRadius))+nodeRadius;
+    node.y = Math.floor(Math.random()*(h-nodeRadius))+nodeRadius;
+    node.text = i;
+    node.degree = getDegree();
+    var acceptable = true;
+    for(var j=0;j<nodes.length;j++){
+      snode = nodes[j];
+      if(distance(snode,node) < (nodeRadius+gap)){
+        acceptable = false;
+        break;
+      }
+    }
+    if(acceptable){
+      nodes.push(node);
+    }else{
+      i--;
+    }
+  }
+  //Create empty adjacency Matrix
+  var adjMatrix = [];
+  for(var i=0;i<nodes.length;i++){
+    x = [];
+    for(var j=0;j<nodes.length;j++){
+      x.push(0);
+    }
+    adjMatrix.push(x);
+  }
+  //Fill adjacency matrix according to degree of the nodes
+  for(var i=0;i<nodes.length;i++){
+    var currNode = nodes[i];
+    var distances = [];
+    for(var j=0;j<nodes.length;j++){
+      if(i != j){
+        distances.push({index:j,distance:distance(currNode,nodes[j])});
+      }
+    }
+    distances = distances.sort(function(a,b){
+      return a.distance - b.distance;
+    });
+
+    for(var j=0; j<currNode.degree;j++){
+      adjMatrix[i][distances[j].index] = 1;
+      adjMatrix[distances[j].index][i] = 1;
+    }
+  }
+
+  return {nodes:nodes,matrix:adjMatrix};
+}
+
+// Class for drawing graphs on the page
+var visualGraph = function(canvas,h,w,agent,nodes,adjMatrix) {
+  this.canvas = canvas;
+  this.h = h;
+  this.w = w;
+  this.two = null;
+  this.agent = agent;
+  this.nodeRadius = 15;
+  this.nodeGroups = [];
+  this.nodes = nodes;
+  this.adjMatrix = adjMatrix;
+  this.unvisitedColor = 'hsl(0, 2%, 76%)';
+  this.frontierColor = 'hsl(200,50%,70%)';
+  this.expandedColor = 'hsl(0,50%,75%)';
+  this.extraDraw = null;
+  this.extraIterate = null;
+
+  this.drawCode = {
+    0:{
+      color:this.unvisitedColor,
+      opacity:1
+    },
+    1:{
+      color:this.frontierColor,
+      opacity:1
+    },
+    2:{
+      color:this.expandedColor,
+      opacity:1
+    }
+  };
+
+  this.init = function(){
+    var self = this;
+    this.canvas.innerHTML = '';
+    this.two = new Two({height:h,width:w}).appendTo(canvas);
+    //Draw edges first so they appear behind nodes.
+    for(var i=0; i < this.adjMatrix.length; i++){
+      for(var j=0; j< this.adjMatrix[i].length; j++){
+        if(this.adjMatrix[i][j]){
+          var line = this.two.makeLine(this.nodes[i].x,this.nodes[i].y,this.nodes[j].x , this.nodes[j].y);
+          $(line._renderer.elem).attr('nodesIndices',i+"_"+j)
+          line.linewidth = 2;
+        }
+      }
+    }
+    //Draw Nodes
+
+    for(var i = 0; i < this.nodes.length; i++){
+      node = this.nodes[i];
+      var circle = this.two.makeCircle(node.x,node.y,this.nodeRadius);
+      circle.fill = this.drawCode[this.agent.getState(i)].color;
+      circle.opacity = this.drawCode[this.agent.getState(i)].opacity;
+      var text = this.two.makeText(node.text,node.x,node.y);
+      var group = this.two.makeGroup(circle,text);
+      this.nodeGroups.push(group);
+      this.two.update();
+      $(group._renderer.elem).attr('nodeIndex',i);
+      if(this.agent.getState(i) == 1){
+        $(group._renderer.elem).css('cursor','pointer');
+        group._renderer.elem.onclick = function(){
+          index = $(this).attr('nodeIndex');
+          self.agent.expand(index);
+          self.iterate();
+        }
+      }
+    }
+    if(this.extraDraw){
+      this.extraDraw();
+    }
+    this.two.update():
+  };
+
+  this.iterate = function(callback){
+    var self = this;
+
+    for(var i = 0; i < this.nodeGroups.length; i++){
+      f_node = this.nodeGroups[i];
+      node = this.nodes[i];
+      state = this.agent.getState(i);
+      f_node._collection[0].fill = this.drawCode[state].color;
+      f_node._collection[0].opacity = this.drawCode[state].opacity;
+      if(state == 1){
+        $(f_node._renderer.elem).css('cursor','pointer');
+        f_node._renderer.elem.onclick = function(){
+          index = $(this).attr('nodeIndex');
+          self.agent.expand(index);
+          self.iterate();
+        }
+      }else{
+        f_node._renderer.elem.onclick = null;
+      }
+    }
+    if(this.extraIterate){
+      this.extraIterate();
+    }
+    this.two.update();
+  };
+
+};

--- a/3-Solving-Problems-By-Searching/index.html
+++ b/3-Solving-Problems-By-Searching/index.html
@@ -35,14 +35,27 @@
 
   <div class="row">
     <div class="col-sm-6 col-md-10 col-md-offset-1" id="content">
+      <div class="row">
+        <div class="col-md-6 col-sm-6">
+          <h1>Solving Problems By Searching</h1>
 
-        <h1>Solving Problems By Searching</h1>
+          <h2>Node Expansion</h2>
+          <p>
+            To search through a graph, a Search Agent needs to <b>expand</b>
+            nodes.
+            The nodes which can be expanded by the Agent together forms the
+            <b>frontier</b>.
+            Expanding a node refers to marking the node as 'expanded' or
+            'visited' and adding its immediate neighbors to the frontier.
+          </p>
+          <p>
+            In the following diagram, 'A' is the initial node and belongs to
+            the frontier. Click on the frontier nodes to see how they are
+            expanded.
+          </p>
+        </div>
+      </div>
 
-        <h2>Node Expansion</h2>
-        <p>Initial State is 'A'</p>
-        <p>
-          Click on a frontier node to see how it expands.
-        </p>
         <div class="row">
           <div class="col-sm-6 col-md-6">
             <div class='btn btn-primary' id='nodeRestartButton'>Restart</div>
@@ -61,12 +74,31 @@
               <center>
                 <h4>Frontier Nodes</h4>
                 <div id='frontierCanvas'>
-
                 </div>
               </center>
             </div>
           </div>
         </div>
+        <div class="row">
+          <div class="col-md-6 col-sm-6">
+            <h2>Getting in the shoes of a Search Agent</h2>
+            <p>
+              Let's see the prespective of a Search Agent as it searches through the graph.<br>
+              Remember, the Agent can only see the nodes which are either expanded or currently present in
+              the frontier.
+            </p>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-sm-6 col-md-6">
+            <div class='btn btn-primary' id='agentViewRestartButton'>Restart</div>
+            <div class="canvas" id='agentViewCanvas' height="400px">
+            </div>
+          </div>
+        </div>
+
+
         <h2>Breadth First Search</h2>
         <p>Click on the cells to block/unblock the cells and restart the simulation.</p>
         <div class = "canvas" id="breadthFirstSearchCanvas" height="300px">

--- a/3-Solving-Problems-By-Searching/index.html
+++ b/3-Solving-Problems-By-Searching/index.html
@@ -4,6 +4,7 @@
   <title>3 Solving Problems By Searching</title>
   <script src="http://code.jquery.com/jquery-1.10.2.js"></script>
   <script type="text/javascript" src="../main.js"></script>
+  <script type="text/javascript" src="./helpers.js"></script>
   <script type="text/javascript" src="./aStarSearch.js"></script>
   <script type="text/javascript" src="./bestFirstSearch.js"></script>
   <script type="text/javascript" src="./breadthFirstSearch.js"></script>

--- a/3-Solving-Problems-By-Searching/index.html
+++ b/3-Solving-Problems-By-Searching/index.html
@@ -11,6 +11,7 @@
   <script type="text/javascript" src="./depthLimitedSearch.js"></script>
   <script type="text/javascript" src="./iterativeDeepening.js"></script>
   <script type="text/javascript" src="./uniformCostSearch.js"></script>
+  <script type="text/javascript" src="./nodeExpansion.js"></script>
 
   <script type="text/javascript" src="./c_aStarSearch.js"></script>
   <script type="text/javascript" src="./c_bestFirstSearch.js"></script>
@@ -19,6 +20,7 @@
   <script type="text/javascript" src="./c_depthLimitedSearch.js"></script>
   <script type="text/javascript" src="./c_iterativeDeepening.js"></script>
   <script type="text/javascript" src="./c_uniformCostSearch.js"></script>
+  <script type="text/javascript" src="./c_nodeExpansion.js"></script>
   <script>
    $(function(){
       $('header').load("../header.html");
@@ -31,51 +33,81 @@
   </header>
 
   <div class="row">
-    <div class="col-sm-6 col-md-offset-3" id="content">
-      <h1>Solving Problems By Searching</h1>
+    <div class="col-sm-6 col-md-10 col-md-offset-1" id="content">
 
-      <h2>Breadth First Search</h2>
-      <p>Click on the cells to block/unblock the cells and restart the simulation.</p>
-      <div class = "canvas" id="breadthFirstSearchCanvas" height="300px">
+        <h1>Solving Problems By Searching</h1>
+
+        <h2>Node Expansion</h2>
+        <p>Initial State is 'A'</p>
+        <p>
+          Click on a frontier node to see how it expands.
+        </p>
+        <div class="row">
+          <div class="col-sm-6 col-md-6">
+            <div class='btn btn-primary' id='nodeRestartButton'>Restart</div>
+            <div class="canvas" id='nodeExpansionCanvas' height="400px">
+            </div>
+          </div>
+          <div class="col-sm-6 col-md-6">
+            <div class="notes">
+              <ul type="none" id='nodeLegend'>
+                <li>Expanded Nodes : <div id='legendExpanded' style="width:15px;height:15px;display: inline-block;"></div></li>
+                <li>Frontier Nodes : <div id='legendFrontier' style="width:15px;height:15px;display: inline-block;"></div></li>
+                <li>Unexplored/Unknown nodes : <div id='legendUnexplored' style="width:15px;height:15px;display: inline-block;"></div></li>
+              </ul>
+            </div>
+            <div id="frontierNodesWrapper" style="border-style:solid; width:50%;height:200px;margin-top:40px">
+              <center>
+                <h4>Frontier Nodes</h4>
+                <div id='frontierCanvas'>
+
+                </div>
+              </center>
+            </div>
+          </div>
+        </div>
+        <h2>Breadth First Search</h2>
+        <p>Click on the cells to block/unblock the cells and restart the simulation.</p>
+        <div class = "canvas" id="breadthFirstSearchCanvas" height="300px">
+        </div>
+
+        <pre id="breadthFirstSearchCode"></pre>
+
+        <h2>Uniform Cost Search</h2>
+        <p>Click on the canvas to restart the simulation</p>
+        <div class = "canvas" id="uniformCostSearchCanvas" height="300px" style="background: rgb(154, 255, 255);">
+        </div>
+
+        <pre id="uniformCostSearchCode"></pre>
+
+        <h2>Depth First Search</h2>
+        <p>Click on the cells to block/unblock the cells and restart the simulation.</p>
+        <div class = "canvas" id="depthFirstSearchCanvas" height="300px">
+        </div>
+
+        <pre id="depthFirstSearchCode"></pre>
+
+        <h2>Depth Limited Search</h2>
+        <p>Click on the canvas to restart the simulation</p>
+        <div class = "canvas" id="depthLimitedSearchCanvas" height="300px" style="background: rgb(154, 255, 255);">
+        </div>
+
+        <pre id="depthLimitedSearchCode"></pre>
+
+        <h2>Iterative Deepening Search</h2>
+        <p>Click on the canvas to restart the simulation</p>
+        <div class = "canvas" id="iterativeDeepeningCanvas" height="300px" style="background: rgb(154, 255, 255);">
+        </div>
+
+        <pre id="iterativeDeepeningCode"></pre>
+
+        <h2>A Star Search</h2>
+        <p>Click on the canvas to restart the simulation</p>
+        <div class = "canvas" id="aStarSearchCanvas" height="300px" style="background: rgb(154, 255, 255);">
+        </div>
+
+        <pre id="aStarSearchCode"></pre>
       </div>
-
-      <pre id="breadthFirstSearchCode"></pre>
-
-      <h2>Uniform Cost Search</h2>
-      <p>Click on the canvas to restart the simulation</p>
-      <div class = "canvas" id="uniformCostSearchCanvas" height="300px" style="background: rgb(154, 255, 255);">
-      </div>
-
-      <pre id="uniformCostSearchCode"></pre>
-
-      <h2>Depth First Search</h2>
-      <p>Click on the cells to block/unblock the cells and restart the simulation.</p>
-      <div class = "canvas" id="depthFirstSearchCanvas" height="300px">
-      </div>
-
-      <pre id="depthFirstSearchCode"></pre>
-
-      <h2>Depth Limited Search</h2>
-      <p>Click on the canvas to restart the simulation</p>
-      <div class = "canvas" id="depthLimitedSearchCanvas" height="300px" style="background: rgb(154, 255, 255);">
-      </div>
-
-      <pre id="depthLimitedSearchCode"></pre>
-
-      <h2>Iterative Deepening Search</h2>
-      <p>Click on the canvas to restart the simulation</p>
-      <div class = "canvas" id="iterativeDeepeningCanvas" height="300px" style="background: rgb(154, 255, 255);">
-      </div>
-
-      <pre id="iterativeDeepeningCode"></pre>
-
-      <h2>A Star Search</h2>
-      <p>Click on the canvas to restart the simulation</p>
-      <div class = "canvas" id="aStarSearchCanvas" height="300px" style="background: rgb(154, 255, 255);">
-      </div>
-
-      <pre id="aStarSearchCode"></pre>
-
     </div>
   </div>
 

--- a/3-Solving-Problems-By-Searching/index.html
+++ b/3-Solving-Problems-By-Searching/index.html
@@ -51,12 +51,12 @@
           <div class="col-sm-6 col-md-6">
             <div class="notes">
               <ul type="none" id='nodeLegend'>
-                <li>Expanded Nodes : <div id='legendExpanded' style="width:15px;height:15px;display: inline-block;"></div></li>
-                <li>Frontier Nodes : <div id='legendFrontier' style="width:15px;height:15px;display: inline-block;"></div></li>
-                <li>Unexplored/Unknown nodes : <div id='legendUnexplored' style="width:15px;height:15px;display: inline-block;"></div></li>
+                <li><div id='legendExpanded' style="width:15px;height:15px;display: inline-block;"></div> Expanded Nodes </li>
+                <li><div id='legendFrontier' style="width:15px;height:15px;display: inline-block;"></div> Frontier Nodes </li>
+                <li><div id='legendUnexplored' style="width:15px;height:15px;display: inline-block;"></div> Unexplored/Unknown Nodes </li>
               </ul>
             </div>
-            <div id="frontierNodesWrapper" style="border-style:solid; width:50%;height:200px;margin-top:40px">
+            <div id="frontierNodesWrapper" style="background-color:hsl(0, 0%, 90%);padding:10px; width:50%;height:200px;margin-top:40px">
               <center>
                 <h4>Frontier Nodes</h4>
                 <div id='frontierCanvas'>

--- a/3-Solving-Problems-By-Searching/nodeExpansion.js
+++ b/3-Solving-Problems-By-Searching/nodeExpansion.js
@@ -1,4 +1,4 @@
-var nodeExpansionProblem = function(adjMatrix,initial){
+var nodeExpansionAgent= function(adjMatrix,initial){
   this.adjMatrix = adjMatrix;
 
   this.UNEXPLORED = 0;

--- a/3-Solving-Problems-By-Searching/nodeExpansion.js
+++ b/3-Solving-Problems-By-Searching/nodeExpansion.js
@@ -1,0 +1,49 @@
+var nodeExpansionProblem = function(adjMatrix,initial){
+  this.adjMatrix = adjMatrix;
+
+  this.UNEXPLORED = 0;
+  this.EXPANDABLE = 1;
+  this.EXPLORED = 2;
+
+  this.frontier = [initial];
+
+  this.nodes = new Array(adjMatrix.length);
+  for(var i=0;i < this.nodes.length; i++){
+    this.nodes[i] = {
+      state : this.UNEXPLORED
+    };
+  }
+  this.nodes[initial] = {state:this.EXPANDABLE}
+  this.getState = function(node){
+    return this.nodes[node].state;
+  };
+
+  this.getNeighbors = function(node){
+    var neighbors = []
+    for(var i=0; i < this.adjMatrix[node] ; i++){
+      if(this.adjMatrix[node][i]){
+        neighbors.push(i);
+      }
+    }
+    return neighbors;
+  };
+
+  this.expand = function(node){
+    this.nodes[node].state = this.EXPLORED;
+    //Remove node from the frontier
+    this.frontier = this.frontier.filter(function(e){ return e!= node});
+    for(var i=0;i < this.adjMatrix[node].length; i++){
+      if(this.adjMatrix[node][i] == 1){
+        neighbor = i;
+        if(this.nodes[neighbor].state == this.UNEXPLORED){
+          this.nodes[neighbor].state = this.EXPANDABLE;
+          this.frontier.push(neighbor);
+        }
+      }
+    }
+  };
+
+  this.getExpandables = function(){
+    return this.frontier;
+  }
+};


### PR DESCRIPTION
Progress on #57 
The following changes were made: 
- Front End rendering of graphs was refactored into a class and shifted to helpers.js. This class could be reused for other visualizations in this chapter. helpers.js also contains a function that can generate random trees. It might prove to be useful later
- A new visualization for the node expansion concept was added where the unvisited nodes are invisible to the user. 
- New texts added to provide relevant context to the user.
- The starting node for the second visualization is randomized every time it is restarted.

I am having a little trouble trying to reuse my code from the first visualization into the second one. I made a class which handles all the rendering operations but since there are extra conditions and logic for the second visualization (like checking if the corresponding nodes of an edge are explored before rendering the edge), I am unable to make a common code for them. Due to this, the current implementation will need some refactoring later.
Please help and review @redblobgames 