### PR TITLE
Fixes bugs and improve UI for chapter 3

### DIFF
--- a/3-Solving-Problems-By-Searching/c_bi-directional.js
+++ b/3-Solving-Problems-By-Searching/c_bi-directional.js
@@ -21,9 +21,9 @@ class BidirectionalDiagram {
     this.final = this.problem.final;
     this.textElement = textElement;
 
-    this.initialColor = 'hsl(0, 20%, 80%)';
+    this.initialColor = 'hsl(0, 2%, 76%)';
     this.edgeColor = 'hsl(0, 2%, 80%)';
-    this.sourceBFSColor = 'hsl(209, 100%, 50%)';
+    this.sourceBFSColor = 'hsl(200,50%,70%)';
     this.destBFSColor = 'hsl(209, 30%, 50%)';
     this.sourceColor = 'hsl(209, 100%, 20%)';
     this.destColor = 'hsl(209, 100%, 20%)';
@@ -80,7 +80,7 @@ class BidirectionalDiagram {
       this.steps++;
       //Update steps in the page
       this.textElement.style('color', this.textColorScale(this.steps));
-      this.textElement.text(this.steps);
+      this.textElement.text(`${this.steps} nodes`);
     }
   }
 
@@ -98,6 +98,10 @@ class BidirectionalDiagram {
         clearInterval(this.intervalFunction)
       }
     }, this.delay);
+  }
+
+  destroy() {
+    clearInterval(this.intervalFunction);
   }
 }
 
@@ -119,14 +123,24 @@ class BFSDiagram extends BidirectionalDiagram {
 }
 
 $(document).ready(function() {
+  let bidirectionalDiagram = new BidirectionalDiagram(d3.select('#bi-directional').select('#biCanvas'), 500, 550);
+  let bfsDiagram = new BFSDiagram(d3.select('#bi-directional').select('#bfsCanvas'), 500, 550)
+
   function init() {
-    let bidirectionalDiagram = new BidirectionalDiagram(d3.select('#backtracking').select('#biCanvas'), 500, 550);
-    let bfsDiagram = new BFSDiagram(d3.select('#backtracking').select('#bfsCanvas'), 500, 550)
+    bidirectionalDiagram = new BidirectionalDiagram(d3.select('#bi-directional').select('#biCanvas'), 500, 550);
+    bfsDiagram = new BFSDiagram(d3.select('#bi-directional').select('#bfsCanvas'), 500, 550)
     let graph = new Graph(500, 530, 1500);
     let problem = new BidirectionalProblem(graph);
-    bidirectionalDiagram.init(problem, d3.select('#backtracking').select('#biStepCount'));
-    bfsDiagram.init(problem, d3.select('#backtracking').select('#bfsStepCount'));
+    bidirectionalDiagram.init(problem, d3.select('#bi-directional').select('#biStepCount'));
+    bfsDiagram.init(problem, d3.select('#bi-directional').select('#bfsStepCount'));
   }
+
+  function restart() {
+    bidirectionalDiagram.destroy();
+    bfsDiagram.destroy();
+    init();
+  }
+
   init();
-  $('#backtracking .restart-button').click(init);
+  $('#bi-directional .restart-button').click(restart);
 });

--- a/3-Solving-Problems-By-Searching/c_costDetails.js
+++ b/3-Solving-Problems-By-Searching/c_costDetails.js
@@ -10,13 +10,8 @@ $(document).ready(function() {
   var colorPathInGraph = function(graphDrawAgent, path) {
       let nodeGroups = graphDrawAgent.nodeGroups;
       for (var i = 0; i < path.path.length; i++) {
-        nodeKey = path.path[i].node;;
-        for (var j = 0; j < nodeGroups.length; j++) {
-          if ($(nodeGroups[j]._renderer.elem).attr('nodeKey') == nodeKey) {
-            nodeGroups[j]._collection[0].fill = 'hsl(108, 96%, 80%)';
-            break;
-          }
-        }
+        nodeKey = path.path[i].node;
+        nodeGroups[nodeKey]._collection[0].fill = 'hsl(108, 96%, 80%)';
       }
       let edges = graphDrawAgent.edges;
       for (var i = 0; i < path.path.length - 1; i++) {
@@ -33,31 +28,30 @@ $(document).ready(function() {
         }
       }
       graphDrawAgent.two.update();
-
     }
     //Function to draw the cost path in the bottom of the graph
   var drawCostPath = function(two, path) {
     two.clear();
     path.path = path.path.reverse();
     let runningCost = 0;
-    var i, x1, x2, y = 20;
+    var i, x1, x2, y = 23;
     for (i = 0; i < path.path.length - 1; i++) {
-      x1 = i * 65 + 20;
-      x2 = (i + 1) * 65 + 20;
-      y = 20;
+      x1 = i * 65 + 30;
+      x2 = (i + 1) * 65 + 30;
+      y = 23;
       line = two.makeLine(x1, y, x2, y);
       line.stroke = 'hsla(202, 100%, 56%, 1)';
       line.linewidth = 5;
       edgeText = two.makeText(path.path[i + 1].cost, (x1 + x2) / 2, 10);
-      rect = two.makeRectangle(x1, y, 30, 30);
+      rect = two.makeCircle(x1, y, 20);
       rect.fill = 'hsl(108, 96%, 80%)';
       nodeText = two.makeText(path.path[i].node, x1, y);
       nodeCost = two.makeText(runningCost, x1, y + 40);
       nodeCost.size = 17;
       runningCost += path.path[i + 1].cost;
     }
-    x1 = i * 65 + 20;
-    rect = two.makeRectangle(x1, y, 40, 40);
+    x1 = i * 65 + 30;
+    rect = two.makeCircle(x1, y, 22);
     rect.fill = 'hsl(108, 96%, 80%)';
     nodeText = two.makeText(path.path[i].node, x1, y);
     nodeText.size = 22;
@@ -95,8 +89,14 @@ $(document).ready(function() {
       //Draw the cost path at the bottom
       drawCostPath(bfsTwo, bfsShortestPath);
       drawCostPath(ucsTwo, ucsShortestPath);
+
+      bfsGraphDrawAgent.highlight(nodeKey);
+      ucsGraphDrawAgent.highlight(nodeKey);
     };
     var onMouseLeave = function() {
+      let nodeKey = $(this).attr('nodeKey');
+      bfsGraphDrawAgent.unhighlight(nodeKey);
+      ucsGraphDrawAgent.unhighlight(nodeKey);
       //Clear everything when mouse leaves
       bfsGraphDrawAgent.iterate();
       ucsGraphDrawAgent.iterate();
@@ -116,6 +116,7 @@ $(document).ready(function() {
     options.nodes.next.onMouseLeave = onMouseLeave;
     options.edges.showCost = true;
     options.nodes.unexplored.clickHandler = function() {};
+    options.nodes.frontier.clickHandler = function() {};
     bfsGraphDrawAgent = new GraphDrawAgent(graphProblem, 'no-costGraphCanvas', options, h, w);
     ucsGraphDrawAgent = new GraphDrawAgent(graphProblem, 'costGraphCanvas', options, h, w);
   };

--- a/3-Solving-Problems-By-Searching/c_nodeExpansion.js
+++ b/3-Solving-Problems-By-Searching/c_nodeExpansion.js
@@ -7,8 +7,11 @@ $(document).ready(function() {
     var graph = new DefaultGraph();
     var graphProblem = new GraphProblem(graph.nodes, graph.edges, 'A', null);
     var graphAgent = new GraphAgent(graphProblem);
-    var frontierNodesAgent = new DrawFrontierAgent('frontierCanvas', 150, 250, graphProblem);
     var options = new DefaultOptions();
+    var frontierNodesAgent = new DrawFrontierAgent('frontierCanvas', 150, 250, graphProblem, options);
+
+    var graphDrawAgent = new GraphDrawAgent(graphProblem, 'nodeExpansionCanvas', options, h, w);
+
     //Function to execute whenever a node is clicked
     var clickHandler = function() {
       //Find out which node has been clicked
@@ -17,10 +20,23 @@ $(document).ready(function() {
       graphAgent.expand(nodeKey);
       graphDrawAgent.iterate();
       frontierNodesAgent.iterate();
+      graphDrawAgent.unhighlight(nodeKey);
     };
     options.nodes.frontier.clickHandler = clickHandler;
-    options.nodes.next.clickHandler = clickHandler
-    var graphDrawAgent = new GraphDrawAgent(graphProblem, 'nodeExpansionCanvas', options, h, w);
+    options.nodes.next.clickHandler = clickHandler;
+
+    options.nodes.frontier.onMouseEnter = function() {
+      let nodeKey = $(this).attr('nodeKey');
+      frontierNodesAgent.highlight(nodeKey);
+      graphDrawAgent.highlight(nodeKey);
+    };
+    options.nodes.frontier.onMouseLeave = function() {
+      let nodeKey = $(this).attr('nodeKey');
+      frontierNodesAgent.unhighlight(nodeKey);
+      graphDrawAgent.unhighlight(nodeKey);
+    };
+
+    graphDrawAgent.reset();
   };
   $('#nodeRestartButton').click(init);
   init();
@@ -32,12 +48,13 @@ $(document).ready(function() {
 $(document).ready(function() {
   var w = 600,
     h = 350;
+  var options = new DefaultOptions();
 
   function init() {
     var graph = new DefaultGraph();
     var graphProblem = new GraphProblem(graph.nodes, graph.edges, String.fromCharCode(65 + Math.random() * 15), null);
     var graphAgent = new GraphAgent(graphProblem);
-    var options = new DefaultOptions();
+    var graphDrawAgent = new GraphDrawAgent(graphProblem, 'agentViewCanvas', options, h, w);
     //For this simulation, unexplored nodes and edges needs to be invisible
     options.nodes.unexplored.opacity = 0;
     options.edges.unvisited.opacity = 0;
@@ -45,22 +62,31 @@ $(document).ready(function() {
       let nodeKey = $(this).attr('nodeKey');
       graphAgent.expand(nodeKey);
       graphDrawAgent.iterate();
+      graphDrawAgent.unhighlight(nodeKey);
     };
     options.nodes.frontier.clickHandler = clickHandler;
     options.nodes.next.clickHandler = clickHandler;
+    options.nodes.frontier.onMouseEnter = function() {
+      let nodeKey = $(this).attr('nodeKey');
+      graphDrawAgent.highlight(nodeKey);
+    }
+    options.nodes.frontier.onMouseLeave = function() {
+      let nodeKey = $(this).attr('nodeKey');
+      graphDrawAgent.unhighlight(nodeKey);
+    }
 
-    var graphDrawAgent = new GraphDrawAgent(graphProblem, 'agentViewCanvas', options, h, w);
+    graphDrawAgent.reset();
   };
   $('#agentViewRestartButton').click(init);
-  $('#legendExpanded').css('background-color', 'hsl(0,50%,75%)');
-  $('#legendFrontier').css('background-color', 'hsl(200,50%,70%)');
-  $('#legendUnexplored').css('background-color', 'hsl(0, 2%, 76%)');
+  $('#legendExpanded').css('background-color', options.nodes.explored.fill);
+  $('#legendFrontier').css('background-color', options.nodes.frontier.fill);
+  $('#legendUnexplored').css('background-color', options.nodes.unexplored.fill);
   init();
 });
 
 
 //Function to draw the frontier nodes
-function DrawFrontierAgent(selector, h, w, problem) {
+function DrawFrontierAgent(selector, h, w, problem, options) {
   this.canvas = document.getElementById(selector);
   this.canvas.innerHTML = '';
   this.two = new Two({
@@ -71,6 +97,7 @@ function DrawFrontierAgent(selector, h, w, problem) {
   this.nodeRadius = 15;
   this.iterate = function() {
     this.two.clear();
+    this.nodeDict = {};
     frontierNodes = this.problem.frontier;
     for (var i = 0; i < frontierNodes.length; i++) {
       node = this.problem.nodes[frontierNodes[i]];
@@ -78,9 +105,24 @@ function DrawFrontierAgent(selector, h, w, problem) {
       var y = (Math.floor(i / 4)) * 50 + 20;
       var circle = this.two.makeCircle(x, y, this.nodeRadius);
       var text = this.two.makeText(node.text, x, y);
-      circle.fill = 'hsl(200,50%,70%)';
+      circle.fill = options.nodes.frontier.fill;
+      var group = this.two.makeGroup(circle, text);
+      this.two.update();
+      this.nodeDict[node.text] = group;
     }
     this.two.update();
+  }
+
+  this.highlight = function(nodeKey) {
+    this.nodeDict[nodeKey]._collection[0].scale = 1.2;
+    this.two.update();
+  }
+
+  this.unhighlight = function(nodeKey) {
+    if (this.nodeDict[nodeKey]) {
+      this.nodeDict[nodeKey]._collection[0].scale = 1;
+      this.two.update();
+    }
   }
   this.iterate();
 }

--- a/3-Solving-Problems-By-Searching/index.html
+++ b/3-Solving-Problems-By-Searching/index.html
@@ -197,11 +197,11 @@
 
       <div class="row">
         <div class="col-sm-6 col-md-6">
-          <div class="canvas" id="costGraphCanvas" height="300px">
+          <div class="canvas" id="no-costGraphCanvas" height="300px">
           </div>
         </div>
         <div class="col-sm-6 col-md-6">
-          <div class="canvas" id="no-costGraphCanvas" height="300px">
+          <div class="canvas" id="costGraphCanvas" height="300px">
           </div>
         </div>
       </div>
@@ -209,9 +209,9 @@
         <div class="col-sm-6 col-md-6">
           <div style="background-color:hsl(0, 0%, 90%);padding:10px; width:100%;height:170px;margin-top:40px">
             <center>
-              <h4>Lowest Cost Path</h4>
-              <h5>Uniform Cost Search (Extension of BFS)</h5>
-              <div id='lowestCostDetailCanvas'>
+              <h4>BFS Shortest Path</h4>
+              <h5>Breadth First Search</h5>
+              <div id='bfsCostDetailCanvas'>
               </div>
             </center>
           </div>
@@ -219,9 +219,9 @@
         <div class="col-sm-6 col-md-6">
           <div style="background-color:hsl(0, 0%, 90%);padding:10px; width:100%;height:170px;margin-top:40px">
             <center>
-              <h4>BFS Shortest Path</h4>
-              <h5>Breadth First Search</h5>
-              <div id='bfsCostDetailCanvas'>
+              <h4>Lowest Cost Path</h4>
+              <h5>Uniform Cost Search (Extension of BFS)</h5>
+              <div id='lowestCostDetailCanvas'>
               </div>
             </center>
           </div>
@@ -375,20 +375,20 @@
       <p>The motivation behind this is that <b>b<sup>d/2</sup> + b<sup>d/2</sup> is smaller than b<sup>d</sup></b></p>
       <p>In the diagram below, we compare the performance between bi-directional BFS and standard BFS side by side. The total number of nodes generated for each strategy is given below the diagram.</p>
       <p>Notice that the further apart the final node is from the initial node, the better bi-directional BFS performs (as compared to standard BFS). Use the restart button to restart the simulation.</p>
-      <div id='backtracking'>
+      <div id='bi-directional'>
         <div class="row">
           <div class='btn btn-primary restart-button'>Restart</div>
         </div>
         <div class="row" style="margin-top:1%">
           <div class="col-md-6">
-            <h2 style="text-align:center;">Bi-directional BFS</h2>
-            <div class="canvas" id='biCanvas' height="300px"></div>
-            <h1 id='biStepCount' style="text-align:center;margin-top:0%;"></h1>
-          </div>
-          <div class="col-md-6">
             <h2 style="text-align:center;">Standard BFS</h2>
             <div class="canvas" id='bfsCanvas' height="300px"></div>
             <h1 id='bfsStepCount' style="text-align:center;margin-top:0%;"></h1>
+          </div>
+          <div class="col-md-6">
+            <h2 style="text-align:center;">Bi-directional BFS</h2>
+            <div class="canvas" id='biCanvas' height="300px"></div>
+            <h1 id='biStepCount' style="text-align:center;margin-top:0%;"></h1>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR does the following:

- Fixes the color inconsistencies among diagrams and legends.
- Makes the nodes in the bfs, dfs and step costs diagram circular.
- Removes edge labels from depth limited search and iterative depth limited search diagrams.
- Switches the positions of standard bfs and bi-directional bfs to have a 'before-after' comparison
- Switches the positions of bfs shortest path and lowest cost path in the step costs diagram for the same reason
- Changes the node count label of bi-directional bfs diagram from *x* to *x nodes*
- Fixes the bug of node count going up-down if the diagram is restarted quickly.
- Adds a hover effect to Node-Expansion diagrams to indicate the node is *clickable* and also to easily compare the frontier nodes with frontier list on the right.

Improvement on #57 