### PR TITLE
Ch22 page no longer refreshes when pressing enter

### DIFF
--- a/22-Natural-Language-Processing/index.html
+++ b/22-Natural-Language-Processing/index.html
@@ -23,7 +23,7 @@
         A sequence of written symbols of length n is called an n-gram with special case “unigram” for 1-gram, “bigram” for 2-gram, and “trigram” for 3-gram.
         A model of the probability distribution of n-letter sequences is thus called an n-gram model.
       </p>
-      <form id="form">
+      <form id="ngram-form">
         <div class="form-group">
           <label >Enter a phrase</label>
           <input type="text" class="form-control" name="firstname" id="phrase"/>
@@ -42,13 +42,13 @@
         Given a text of some kind, to decide which of a predefined set of classes it belongs to is called text classification.
         Language identification , genre classification ,sentiment analysis and spam detection are examples of text classification.
       </p>
-      <form id="form">
+      <form id="classification-form">
         <div class="form-group">
           <label >Enter English or French text here.</label>
           <input type="text" class="form-control"  id="test_phrase"/>
         </div>
         <div class="form-group">
-          <button type="button" class="btn btn-success" id="test_button" onclick="go();">Guess Language</button>
+          <button type="input" class="btn btn-success" id="test_button" onclick="go();">Guess Language</button>
         </div>
       <h2>Language : <span id="test_result"></span></h2>
       </form>

--- a/22-Natural-Language-Processing/nGramModels.js
+++ b/22-Natural-Language-Processing/nGramModels.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
-    $('#form').submit(function() {
+    $('#ngram-form').submit(function(e) {
             var str = $('#phrase').val();
             var charUnigram;
             $('#character-level-unigram').empty();
@@ -20,6 +20,12 @@ $(document).ready(function() {
                 $('#character-level-trigram').append("<kbd>"+a+b+c+"</kbd>");
                 $('#character-level-trigram').append(",  ");
             }
-        return false;
+        
+        // prevent the form from submitting and refreshing the page 
+        e.preventDefault();
     });
+
+    $('#classification-form').submit(function(e){
+        e.preventDefault();
+    })
 });


### PR DESCRIPTION
This fixes #112 

The problem was both forms had id `#form` and there was nothing to prevent the default browser behavior when submitting the second form. I gave them more descriptive id's so it's clear which is being referred to. 

The other solution would have been to no longer have it as a form, but I kept it because having it as a form and the button being of type submit is convenient because the default browser behavior is that enter will trigger a click on that button (so we don't have to have a keypress listener).