### PR TITLE
#117 fix: Sometimes SimulatedAnnealing#getRandomState() generates number which is out of range

### DIFF
--- a/4-Beyond-Classical-Search/simulatedAnnealing.js
+++ b/4-Beyond-Classical-Search/simulatedAnnealing.js
@@ -22,9 +22,13 @@ class SimulatedAnnealing {
       temp: temperature
     };
   }
+  /**
+   * @see https://developer.mozilla.org/nl/docs/Web/JavaScript/Reference/Global_Objects/Math/random#Getting_a_random_integer_between_two_values
+   * @returns {Number}
+   */
   getRandomState() {
     let mini = 0;
     let maxi = this.states.length;
-    return Math.floor(Math.random() * (maxi - mini + 1)) + mini;
+    return  Math.floor(Math.random() * (maxi - mini)) + mini;
   }
 }


### PR DESCRIPTION
Sometimes SimulatedAnnealing#getRandomState() generates number which is out of range. It happens because that method generates numbers inclusive. And we have as follows:
```js
// this.states = [0...99]
// this.getRandomState() --> [0..100]

let diff = undefined - this.states[this.current];
```

https://github.com/aimacode/aima-javascript/blob/master/4-Beyond-Classical-Search/simulatedAnnealing.js#L11

![image](https://user-images.githubusercontent.com/2478262/32885926-177a8f82-cad0-11e7-9654-a01e03dd0823.png)
